### PR TITLE
feat: export Options interface in TypeScript declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ export interface Profile {
   }
 }
 
-interface Options {
+export interface Options {
   clientID: string;
   teamID: string;
   keyID: string;


### PR DESCRIPTION
Resolves issues that occur after updating NestJS v11.

```
'extends' clause of exported class 'AppleStrategy' has or is using private name 'Options'.
```